### PR TITLE
Enable Basic auth to proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ metadata:
   name: my-awesome-app
 type: application
 resources:
-  proxyies:
+  proxies:
     /api/v1: "http://api.of.external.service/v1"
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If there is none, a new certificate is created and used.
 ## Proxy
 
 You can proxy existing (OData) backend services to get around Access-Control-Allow-Origin (CORS) errors.
-To do so, you can add a hash of proxied paths in your `ui5.yml`. Example:
+To do so, you can add a hash of proxied paths in your `ui5.yml`. Example (auth is optional):
 ```
 # ui5.yml
 specVersion: '0.1'
@@ -48,6 +48,7 @@ type: application
 resources:
   proxies:
     /api/v1: "http://api.of.external.service/v1"
+	auth: "myproxyusername:myproxypassword"
 ```
 
 ## Contributing

--- a/lib/middleware/serveProxies.js
+++ b/lib/middleware/serveProxies.js
@@ -68,7 +68,12 @@ function createUri(uriParam, proxyDefinitions) {
  * @returns {function} Returns a server middleware closure.
  */
 function createMiddleware(proxyDefinitions) {
-	let proxy = httpProxy.createProxyServer({});
+	let proxyServerParameters = {};
+	if (proxyDefinitions.auth)
+	{
+		proxyServerParameters.auth = proxyDefinitions.auth;
+	}
+	let proxy = httpProxy.createProxyServer(proxyServerParameters);
 
 	return function serveResources(req, res, next) {
 		if (proxyDefinitions == undefined) {


### PR DESCRIPTION
Thank you for your pull-request on ui5-server with the enablement of proxies! This is great.

Another thing I would want to see in the proxy is basic authentication. I've created a simple pull request where we could use this feature of http-proxy.